### PR TITLE
remove ooqp_catkin and use Findooqp.cmake instead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,9 +63,10 @@ add_library(ooqpei
 	src/OoqpEigenInterface.cpp
 	src/QuadraticProblemFormulation.cpp
 )
-add_dependencies(ooqpei ooqp)
+#add_dependencies(ooqpei)
 target_link_libraries(ooqpei
     ${OOQP_LIBRARIES}
+    blas ma27 gfortran
     ${catkin_LIBRARIES}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,31 +38,34 @@
 
 cmake_minimum_required(VERSION 2.8.3)
 project(ooqp_eigen_interface)
+set(CMAKE_VERBOSE_MAKEFILE on)
 
+set(CMAKE_CXX_FLAGS "-fPIC")
 add_definitions(-std=c++11)
 
 find_package(Eigen3 REQUIRED)
-find_package(catkin REQUIRED COMPONENTS
-    ooqp_catkin
-)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
+MESSAGE( STATUS "CMAKE_MODULE_PATH: " ${CMAKE_MODULE_PATH} )
+find_package(ooqp REQUIRED)
+find_package(catkin REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIR}
   LIBRARIES ooqpei
-  CATKIN_DEPENDS ooqp_catkin
-  DEPENDS 
+  DEPENDS
 )
 
 include_directories(include)
 include_directories(${EIGEN3_INCLUDE_DIR})
 include_directories(${catkin_INCLUDE_DIRS})
 
-add_library(ooqpei 
+add_library(ooqpei
 	src/OoqpEigenInterface.cpp
-	src/QuadraticProblemFormulation.cpp 
+	src/QuadraticProblemFormulation.cpp
 )
-add_dependencies(ooqpei ooqp_catkin)
-target_link_libraries(ooqpei 
+add_dependencies(ooqpei ooqp)
+target_link_libraries(ooqpei
+    ${OOQP_LIBRARIES}
     ${catkin_LIBRARIES}
 )
 
@@ -74,12 +77,13 @@ install(TARGETS ooqpei
 install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
-catkin_add_gtest(test_ooqpei 
+catkin_add_gtest(test_ooqpei
     test/test_main.cpp
     test/OoqpEigenInterface_test.cpp
     test/QuadraticProblemFormulation_test.cpp
 )
-target_link_libraries(test_ooqpei 
-    ooqpei 
+target_link_libraries(test_ooqpei
+    ooqpei
+    ${OOQP_LIBRARIES}
     ${catkin_LIBRARIES}
 )

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ To build, clone the latest version from this repository into your catkin workspa
 	cd ../
 	catkin_make
 
+### Building using Findooqp.cmake
+Since ooqp_catkin can't be distributed, I modified this package to add a find_package command to search for ooqp on the system in the standard directories `usr/local/include` and `/usr/local/lib`. You need to build ooqp with the `-fPIC` option. To do so run:
+
+	export CXXFLAGS="-O -fPIC"
+	make -j4
+	sudo make install
+
+After that you can build using `catkin_make` or `catkin build`. If using the former change CMakeLists.txt
+
+	set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/${PROJECT_NAME}/cmake")
+
+Otherwise leave `CMAKE_MODULE_PATH` alone.
 
 Usage
 ------------

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To build, clone the latest version from this repository into your catkin workspa
 ### Building using Findooqp.cmake
 Since ooqp_catkin can't be distributed, I modified this package to add a find_package command to search for ooqp on the system in the standard directories `usr/local/include` and `/usr/local/lib`. You need to build ooqp and ma27 with the `-fPIC` option. To do so run in the ma27 folder:
 
-  ./configure FFLAGS="-O -fPIC"
+	./configure FFLAGS="-O -fPIC"
 	make
 	sudo make install
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,13 @@ To build, clone the latest version from this repository into your catkin workspa
 	catkin_make
 
 ### Building using Findooqp.cmake
-Since ooqp_catkin can't be distributed, I modified this package to add a find_package command to search for ooqp on the system in the standard directories `usr/local/include` and `/usr/local/lib`. You need to build ooqp with the `-fPIC` option. To do so run:
+Since ooqp_catkin can't be distributed, I modified this package to add a find_package command to search for ooqp on the system in the standard directories `usr/local/include` and `/usr/local/lib`. You need to build ooqp and ma27 with the `-fPIC` option. To do so run in the ma27 folder:
+
+  ./configure FFLAGS="-O -fPIC"
+	make
+	sudo make install
+
+And run in the ooqp folder
 
 	export CXXFLAGS="-O -fPIC"
 	make -j4

--- a/cmake/Findooqp.cmake
+++ b/cmake/Findooqp.cmake
@@ -1,0 +1,116 @@
+# - Try to find ooqp
+# Once done tihs will define
+#   OOQP_FOUND
+#   OOQP_INCLUDE_DIRS
+#   OOQP_LIBRARIES
+#   OOQP_DEFINITIONS
+
+find_path(OOQP_INCLUDE_DIR NAMES
+  ooqp/cBounds.h
+  ooqp/DeSymIndefSolver.h
+  ooqp/MehrotraSolver.h
+  ooqp/QpBoundVars.h
+  ooqp/SmartPointer.h
+  ooqp/cMpsReader.h
+  ooqp/DeSymPSDSolver.h
+  ooqp/MpsReader.h
+  ooqp/QpGenData.h
+  ooqp/Solver.h
+  ooqp/cMpsReaderPetsc.h
+  ooqp/DoubleLinearSolver.h
+  ooqp/OoqpBlas.h
+  ooqp/QpGenDense.h
+  ooqp/SparseGenMatrix.h
+  ooqp/cQpBoundDense.h
+  ooqp/DoubleMatrix.h
+  ooqp/OoqpMonitorData.h
+  ooqp/QpGenDenseLinsys.h
+  ooqp/SparseGenMatrixHandle.h
+  ooqp/cQpBound.h
+  ooqp/DoubleMatrixHandle.h
+  ooqp/OoqpMonitor.h
+  ooqp/QpGenDriver.h
+  ooqp/SparseLinearAlgebraPackage.h
+  ooqp/cQpBoundPetsc.h
+  ooqp/DoubleMatrixTypes.h
+  ooqp/OoqpPetscMonitor.h
+  ooqp/QpGen.h
+  ooqp/SparseStorage.h
+  ooqp/cQpGenDense.h
+  ooqp/GondzioSolver.h
+  ooqp/OoqpStartStrategy.h
+  ooqp/QpGenLinsys.h
+  ooqp/SparseStorageHandle.h
+  ooqp/cQpGen.h
+  ooqp/hash.h
+  ooqp/OoqpVector.h
+  ooqp/QpGenResiduals.h
+  ooqp/SparseSymMatrix.h
+  ooqp/cQpGenPetsc.h
+  ooqp/HuberData.h
+  ooqp/OoqpVectorHandle.h
+  ooqp/QpGenSparseLinsys.h
+  ooqp/SparseSymMatrixHandle.h
+  ooqp/cQpGenSparse.h
+  ooqp/Huber.h
+  ooqp/OoqpVersion.h
+  ooqp/QpGenSparseMa27.h
+  ooqp/Status.h
+  ooqp/Data.h
+  ooqp/HuberLinsys.h
+  ooqp/ProblemFormulation.h
+  ooqp/QpGenSparseMa57.h
+  ooqp/SvmData.h
+  ooqp/DenseGenMatrix.h
+  ooqp/HuberResiduals.h
+  ooqp/QpBoundData.h
+  ooqp/QpGenSparseOblio.h
+  ooqp/Svm.h
+  ooqp/DenseGenMatrixHandle.h
+  ooqp/HuberVars.h
+  ooqp/QpBoundDense.h
+  ooqp/QpGenSparseSeq.h
+  ooqp/SvmLinsys.h
+  ooqp/DenseLinearAlgebraPackage.h
+  ooqp/IotrRefCount.h
+  ooqp/QpBoundDenseLinsys.h
+  ooqp/QpGenSparseSuperLu.h
+  ooqp/SvmResiduals.h
+  ooqp/DenseStorage.h
+  ooqp/LinearAlgebraPackage.h
+  ooqp/QpBound.h
+  ooqp/QpGenVars.h
+  ooqp/SvmVars.h
+  ooqp/DenseStorageHandle.h
+  ooqp/LinearSystem.h
+  ooqp/QpBoundLinsys.h
+  ooqp/Residuals.h
+  ooqp/Variables.h
+  ooqp/DenseSymMatrix.h
+  ooqp/Ma27Solver.h
+  ooqp/QpBoundPetsc.h
+  ooqp/SimpleVector.h
+  ooqp/VectorUtilities.h
+  ooqp/DenseSymMatrixHandle.h
+  ooqp/Ma57Solver.h
+  ooqp/QpBoundResiduals.h
+  ooqp/SimpleVectorHandle.h
+  HINTS /usr/local/include
+)
+
+find_library(OOQP_LIBRARY NAMES ooqpbase ooqpdense ooqpgensparse ooqpmehrotra
+  ooqpbound ooqpgendense ooqpgondzio ooqpsparse
+  HINTS /usr/local/lib
+)
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set OOQP_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(ooqp  DEFAULT_MSG
+                                  OOQP_LIBRARY OOQP_INCLUDE_DIR)
+
+mark_as_advanced(OOQP_INCLUDE_DIR OOQP_LIBRARY)
+set(OOQP_LIBRARIES ${OOQP_LIBRARY} )
+set(OOQP_INCLUDE_DIRS ${OOQP_INCLUDE_DIR} )
+MESSAGE( STATUS "OOQP_INCLUDE_DIRS: " ${OOQP_INCLUDE_DIRS} )
+MESSAGE( STATUS "OOQP_LIBRARIES: " ${OOQP_LIBRARIES} )

--- a/cmake/Findooqp.cmake
+++ b/cmake/Findooqp.cmake
@@ -98,9 +98,18 @@ find_path(OOQP_INCLUDE_DIR NAMES
   HINTS /usr/local/include
 )
 
-find_library(OOQP_LIBRARY NAMES ooqpbase ooqpdense ooqpgensparse ooqpmehrotra
-  ooqpbound ooqpgendense ooqpgondzio ooqpsparse
-  HINTS /usr/local/lib
+set(LIB_DIR /usr/local/lib)
+
+find_library(OOQP_BASE NAMES ooqpbase HINTS ${LIB_DIR})
+find_library(OOQP_DENSE NAMES ooqpdense HINTS ${LIB_DIR})
+find_library(OOQP_GENSPARSE NAMES ooqpgensparse HINTS ${LIB_DIR})
+find_library(OOQP_MEHROTRA NAMES ooqpmehrotra HINTS ${LIB_DIR})
+find_library(OOQP_BOUND NAMES ooqpbound HINTS ${LIB_DIR})
+find_library(OOQP_GENDENSE NAMES ooqpgendense HINTS ${LIB_DIR})
+find_library(OOQP_GONDZIO NAMES ooqpgondzio HINTS ${LIB_DIR})
+find_library(OOQP_SPARSE NAMES ooqpsparse HINTS ${LIB_DIR})
+
+set(OOQP_LIBRARY ${OOQP_BASE} ${OOQP_DENSE} ${OOQP_GENSPARSE} ${OOQP_MEHROTRA} ${OOQP_BOUND} ${OOQP_GENDENSE} ${OOQP_GONDZIO} ${OOQP_SPARSE}
 )
 
 include(FindPackageHandleStandardArgs)

--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,5 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>eigen</build_depend>
-  <build_depend>ooqp_catkin</build_depend>
-  <run_depend>ooqp_catkin</run_depend>
   <test_depend>gtest</test_depend>
 </package>

--- a/src/OoqpEigenInterface.cpp
+++ b/src/OoqpEigenInterface.cpp
@@ -42,12 +42,12 @@
 #include "ooqp_eigen_interface/OoqpEigenInterface.hpp"
 #include <stdexcept>
 #include "ooqp_eigen_interface/ooqpei_assert_macros.hpp"
-#include "QpGenData.h"
-#include "QpGenVars.h"
-#include "QpGenResiduals.h"
-#include "GondzioSolver.h"
-#include "QpGenSparseMa27.h"
-#include "Status.h"
+#include "ooqp/QpGenData.h"
+#include "ooqp/QpGenVars.h"
+#include "ooqp/QpGenResiduals.h"
+#include "ooqp/GondzioSolver.h"
+#include "ooqp/QpGenSparseMa27.h"
+#include "ooqp/Status.h"
 #include "ooqp_eigen_interface/ooqpei_numerical_comparisons.hpp"
 
 using namespace Eigen;
@@ -326,4 +326,3 @@ void OoqpEigenInterface::printSolution(const int status, const Eigen::VectorXd& 
 }
 
 } /* namespace ooqpei */
-


### PR DESCRIPTION
Since ooqp_catkin can't be distributed I wrote a Findooqp.cmake file to search the system for ooqp using the default path where it gets installed. I did this because the cmake branch isn't up to date with the catkin branch.

Not necessarily expecting to get this merged in (though if there are any modifications required to get this merged in, I don't mind doing them). Mostly putting this out there for anyone else not from ethz-asl but still wanting to use this package.